### PR TITLE
IEXParser: fix _get_session_id to support '\n' (fix #9)

### DIFF
--- a/IEXTools/IEXparser.py
+++ b/IEXTools/IEXparser.py
@@ -155,10 +155,19 @@ class Parser(object):
                 self.version + self.reserved + self.protocol_id + self.channel_id
             )
             with open(file_path, "rb") as market_file:
-                for line in market_file:
-                    if iex_header_start in line:
-                        line = line.split(iex_header_start)[1]
-                        return line[:4]
+                found = False
+                i = 0
+                while not found:
+                    cur_chunk = market_file.read(1)
+                    if cur_chunk[0] == iex_header_start[i]:
+                        i += 1
+                        if i == len(iex_header_start):
+                            found = True
+                    else:
+                        i = 0
+
+                if found:
+                    return market_file.read(4)
         raise ProtocolException("Session ID could not be found in the supplied file")
 
     def read_next_line(self) -> bytes:


### PR DESCRIPTION
Hello,

First, I would like to thank you for this **amazing** repository :)

I investigated the issue #9. I tracked down the error to the `_get_session_id` method that create an invalid header length (11 instead of 12 for this file)...
The reason is that the session_id contains a '\n', and when you iterate with:
```python
for line in market_file:
```
the line is split at the first "\n", which is not something you should do when dealing with a binary file. I fixed the method `_get_session_id` using a similar solution present in `_seek_header`. I believe an util function could solve both cases, but I wanted to avoid messing around too much...

I hope this will help !
Best regards,

