### PR TITLE
Make Path Configurable and add Support for GZIP PCAP files

### DIFF
--- a/IEXTools/IEXDownloader.py
+++ b/IEXTools/IEXDownloader.py
@@ -17,19 +17,19 @@ from typing import Dict
 
 
 class DataDownloader(object):
-    def __init__(self) -> None:
+    def __init__(self, path: str = None) -> None:
         """
         Initiate the class with the IEX API endpoint information and
         initializes the folder to put the downloaded data into.
         """
         self.base_endpoint = "https://api.iextrading.com/1.0/"
 
-        if sys.argv[0]:
-            os.chdir(os.path.dirname(sys.argv[0]))
-
-        self.directory = "IEX_data"
-        if not os.path.exists(self.directory):
-            os.makedirs(self.directory)
+        if path:
+            self.directory = path
+        else:
+            self.directory = "IEX_data"
+            if not os.path.exists(self.directory):
+                os.makedirs(self.directory)
 
     def _get_endpoint(self, date: datetime) -> str:
         """

--- a/IEXTools/IEXparser.py
+++ b/IEXTools/IEXparser.py
@@ -35,8 +35,9 @@ Parsed 1,000,000 messages in 54.0 seconds -- 18512.9 messages per second
 '''
 """
 from __future__ import annotations
-import struct
 from datetime import datetime, timezone
+import gzip
+import struct
 from . import messages
 from typing import BinaryIO, Optional, Iterator, Union, List, Tuple, Dict
 from .IEXHISTExceptions import ProtocolException
@@ -133,7 +134,10 @@ class Parser(object):
         Function to load a TOPS File into the parser. Simply returns a file
         object which other methods will iterate over.
         """
-        return open(file_path, "rb")
+        if file_path.endswith('.gz'):
+            return gzip.open(file_path, "rb")
+        else:
+            return open(file_path, "rb")
 
     def _get_session_id(self, file_path: str) -> bytes:
         """
@@ -154,7 +158,7 @@ class Parser(object):
             iex_header_start = (
                 self.version + self.reserved + self.protocol_id + self.channel_id
             )
-            with open(file_path, "rb") as market_file:
+            with self._load(file_path) as market_file:
                 found = False
                 i = 0
                 while not found:


### PR DESCRIPTION
- Added a path parameter to allow saving to an arbitrary location. The default parameter will preserve the current behavior.

- If the PCAP file ends in .gz decompress on the fly. This simplifies single pass through use cases such as storing all the trades in a DB. Current behavior is to read the entire file and then error.